### PR TITLE
allow promise.all to finish

### DIFF
--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -104,13 +104,25 @@ module.exports = class BaseDownloadController extends CompositeController {
     let items = objectPath.get(file, ['items']);
 
     if (Array.isArray(file)) {
-      return await Promise.all(file.map(async f => {
-        await this._decomposeFile(f);
+      let error;
+      let res = await Promise.all(file.map(async f => {
+        try {
+          return await this._decomposeFile(f);
+        } catch (e) {
+          error = error || e;
+        }
       }));
+      return error ? Promise.reject(error) : res;
     } else if (kind.toLowerCase() == 'list' && Array.isArray(items)) {
-      return await Promise.all(items.map(async f => {
-        await this._decomposeFile(f);
+      let error;
+      let res = await Promise.all(items.map(async f => {
+        try {
+          return await this._decomposeFile(f);
+        } catch (e) {
+          error = error || e;
+        }
       }));
+      return error ? Promise.reject(error) : res;
     } else if (file) {
       return await this._saveChild(file);
     }
@@ -121,6 +133,7 @@ module.exports = class BaseDownloadController extends CompositeController {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       return Promise.reject(res);
     }
+    return res;
   }
 
   async download() {


### PR DESCRIPTION
promise.all should finish applying all child resources from a downloaded file before rejecting out. use optional flag to allow further files to be downloaded and applied from the requests list