### PR TITLE
Dont update original request array

### DIFF
--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -114,7 +114,7 @@ module.exports = class BaseDownloadController extends CompositeController {
     }
 
     if (delRequestLMHeaders.length > 0) {
-      console.log(delRequestLMHeaders);
+      console.dir(delRequestLMHeaders, { depth: null });
       let patchObject = { spec: { requests: delRequestLMHeaders } };
       let cont = await this.patchSelf(patchObject);
       if (!cont) return;

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -35,7 +35,6 @@ module.exports = class BaseDownloadController extends CompositeController {
     let optionalResourceFailure = 0;
     let lastModifiedArray = objectPath.get(this.data, ['object', 'status', 'last-modified'], []);
     let newLastModifiedArray = [];
-    let delRequestLMHeaders = [];
 
     for (var i = 0; i < requests.length; i++) {
       let request = requests[i];
@@ -46,6 +45,12 @@ module.exports = class BaseDownloadController extends CompositeController {
       let optional = request.optional || false;
       let reqOpt = clone(request.options);
       let url = objectPath.get(request, 'options.uri') || objectPath.get(request, 'options.url');
+
+      if (objectPath.has(request, 'options.headers.If-Modified-Since') || objectPath.has(request, 'options.headers.If-None-Match')) {
+        this.log.warn('Should not include If-Modified-Since/If-None-Match in definition headers, removing from request');
+        objectPath.del(request, 'options.headers.If-Modified-Since');
+        objectPath.del(request, 'options.headers.If-None-Match');
+      }
 
       let imsObj = lastModifiedArray.find((el) => objectPath.get(el, 'hash') == requestHash && objectPath.has(el, 'last-modified'));
       let fileCached = await fs.pathExists(fileCachePath);
@@ -68,19 +73,12 @@ module.exports = class BaseDownloadController extends CompositeController {
             await fs.outputJson(fileCachePath, file);
             newLastModifiedArray[i] = { hash: requestHash, url: url, 'last-modified': resLM };
           }
-        } else if (res.statusCode == 304) {
+        } else if (res.statusCode == 304 && fileCached) {
           this.log.debug(`Download ${res.statusCode} Not Modified ${url}`);
-          if (fileCached) {
-            file = await fs.readJson(fileCachePath);
-            let resLM = objectPath.get(res, 'headers.last-modified');
-            if (resLM) {
-              newLastModifiedArray[i] = { hash: requestHash, url: url, 'last-modified': resLM };
-            }
-          } else {
-            objectPath.set(delRequestLMHeaders, [i, 'options', 'headers', 'If-Modified-Since'], null);
-            // objectPath.del(request, 'options.headers.If-None-Match');
-            this.log.debug(`Failed to find cached file, removing headers.If-Modified-Since to try again next time: ${res.statusCode} | ${url}`);
-            ++optionalResourceFailure;
+          file = await fs.readJson(fileCachePath);
+          let resLM = objectPath.get(res, 'headers.last-modified');
+          if (resLM) {
+            newLastModifiedArray[i] = { hash: requestHash, url: url, 'last-modified': resLM };
           }
         } else {
           this.log.debug(`Download failed: ${res.statusCode} | ${url}`);
@@ -111,13 +109,6 @@ module.exports = class BaseDownloadController extends CompositeController {
         }
       }
 
-    }
-
-    if (delRequestLMHeaders.length > 0) {
-      console.dir(delRequestLMHeaders, { depth: null });
-      let patchObject = { spec: { requests: delRequestLMHeaders } };
-      let cont = await this.patchSelf(patchObject);
-      if (!cont) return;
     }
 
     // update the last-modified array

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -48,8 +48,8 @@ module.exports = class BaseDownloadController extends CompositeController {
 
       if (objectPath.has(request, 'options.headers.If-Modified-Since') || objectPath.has(request, 'options.headers.If-None-Match')) {
         this.log.warn('Should not include If-Modified-Since/If-None-Match in definition headers, removing from request');
-        objectPath.del(request, 'options.headers.If-Modified-Since');
-        objectPath.del(request, 'options.headers.If-None-Match');
+        objectPath.del(reqOpt, 'options.headers.If-Modified-Since');
+        objectPath.del(reqOpt, 'options.headers.If-None-Match');
       }
 
       let imsObj = lastModifiedArray.find((el) => objectPath.get(el, 'hash') == requestHash && objectPath.has(el, 'last-modified'));

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -47,7 +47,7 @@ module.exports = class BaseDownloadController extends CompositeController {
       let url = objectPath.get(request, 'options.uri') || objectPath.get(request, 'options.url');
 
       if (objectPath.has(request, 'options.headers.If-Modified-Since') || objectPath.has(request, 'options.headers.If-None-Match')) {
-        this.log.warn('Should not include If-Modified-Since/If-None-Match in definition headers, removing from request');
+        this.log.warn('Should not include If-Modified-Since/If-None-Match in definition headers, removing from request..');
         objectPath.del(reqOpt, 'headers.If-Modified-Since');
         objectPath.del(reqOpt, 'headers.If-None-Match');
       }

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -48,14 +48,15 @@ module.exports = class BaseDownloadController extends CompositeController {
 
       if (objectPath.has(request, 'options.headers.If-Modified-Since') || objectPath.has(request, 'options.headers.If-None-Match')) {
         this.log.warn('Should not include If-Modified-Since/If-None-Match in definition headers, removing from request');
-        objectPath.del(reqOpt, 'options.headers.If-Modified-Since');
-        objectPath.del(reqOpt, 'options.headers.If-None-Match');
+        objectPath.del(reqOpt, 'headers.If-Modified-Since');
+        objectPath.del(reqOpt, 'headers.If-None-Match');
       }
 
       let imsObj = lastModifiedArray.find((el) => objectPath.get(el, 'hash') == requestHash && objectPath.has(el, 'last-modified'));
       let fileCached = await fs.pathExists(fileCachePath);
       this.log.debug(`Request Hash ${requestHash} ${imsObj ? 'found' : 'not found'} in .status.last-modified array and file ${fileCached ? 'is' : 'is not'} cached`);
       if (imsObj && fileCached) {
+        this.log.debug(`Adding headers.If-Modified-Since to request from Request Hash ${requestHash}`);
         objectPath.set(reqOpt, 'headers.If-Modified-Since', objectPath.get(imsObj, 'last-modified'));
       }
 

--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -35,6 +35,7 @@ module.exports = class BaseDownloadController extends CompositeController {
     let optionalResourceFailure = 0;
     let lastModifiedArray = objectPath.get(this.data, ['object', 'status', 'last-modified'], []);
     let newLastModifiedArray = [];
+    let delRequestLMHeaders = [];
 
     for (var i = 0; i < requests.length; i++) {
       let request = requests[i];
@@ -76,7 +77,7 @@ module.exports = class BaseDownloadController extends CompositeController {
               newLastModifiedArray[i] = { hash: requestHash, url: url, 'last-modified': resLM };
             }
           } else {
-            objectPath.del(request, 'options.headers.If-Modified-Since');
+            objectPath.set(delRequestLMHeaders, [i, 'options', 'headers', 'If-Modified-Since'], null);
             // objectPath.del(request, 'options.headers.If-None-Match');
             this.log.debug(`Failed to find cached file, removing headers.If-Modified-Since to try again next time: ${res.statusCode} | ${url}`);
             ++optionalResourceFailure;
@@ -112,8 +113,9 @@ module.exports = class BaseDownloadController extends CompositeController {
 
     }
 
-    if (objectPath.has(this.data, ['object', 'spec', 'requests'])) {
-      let patchObject = { spec: { requests: objectPath.get(this.data, ['object', 'spec', 'requests']) } };
+    if (delRequestLMHeaders.length > 0) {
+      console.log(delRequestLMHeaders);
+      let patchObject = { spec: { requests: delRequestLMHeaders } };
       let cont = await this.patchSelf(patchObject);
       if (!cont) return;
     }


### PR DESCRIPTION
just remove if modified since from the request and move on. This seems to be causing odd behavior, where the versions keep flipping back and forth in the url when we update the whole array. some transient modfied event comes through and switches it back, while the new one is trying to flip it forward. bad juju.