### PR TITLE
Catch kube errors when no status code returned

### DIFF
--- a/lib/BaseDownloadController.js
+++ b/lib/BaseDownloadController.js
@@ -154,7 +154,7 @@ module.exports = class BaseDownloadController extends CompositeController {
 
   async _saveChild(child) {
     let res = await this.applyChild(child);
-    if (res.statusCode < 200 || res.statusCode >= 300) {
+    if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
       return Promise.reject(res);
     }
     return res;

--- a/lib/CompositeController.js
+++ b/lib/CompositeController.js
@@ -109,13 +109,11 @@ module.exports = class CompositeController extends BaseController {
   }
 
   async reconcileChildren() {
-    this.log.info(`ReconcileChildren called by ${objectPath.get(this.data, ['object', 'metadata', 'selfLink'])}`);
-
     let newChildren = objectPath.get(this.status, ['children'], {}); // children that were computed this cycle
     let oldChildren = objectPath.get(this.data, ['object', 'status', 'children'], {}); // children that existed at the start of the cycle
 
-    if (Object.entries(newChildren).length === 0 && Object.entries(oldChildren).length > 0) {
-      this.log.warn('No children found this cycle -- More than 0 found previously');
+    if (Object.entries(newChildren).length < Object.entries(oldChildren).length) {
+      this.log.info(`Less children found this cycle then previously (${Object.entries(newChildren).length} < ${Object.entries(oldChildren).length}).. ReconcileChildren called by ${objectPath.get(this.data, ['object', 'metadata', 'selfLink'])}`);
     }
 
     let res = await Promise.all(Object.entries(oldChildren).map(async ([selfLink, child]) => {


### PR DESCRIPTION
If an error from kube comes back when applying a child and doesn't have a status code, this child will get deleted. This fixes that by defining a response with no status codde as an error.